### PR TITLE
Correction bugs + modifs Meson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 builddir/
+.vscode

--- a/Code/game.c
+++ b/Code/game.c
@@ -31,7 +31,7 @@ struct Ball ball = {0, 0, 5.0, 3.0};
 
 time_t start, stop;
 
-unsigned __int16 score = 0;
+unsigned int score = 0;
 int meilleur_score;
 char score_text[50] = "Pong, première partie";
 
@@ -62,7 +62,7 @@ gboolean keyboard_manager(GtkWidget *widget, GdkEventKey *event, gpointer user_d
 void quitter(){
     if(meilleur_score < score){
         FILE *save = fopen("score.bin", "w+b");
-        fwrite(&score, sizeof(unsigned __int16), 1, save);
+        fwrite(&score, sizeof(unsigned int), 1, save);
         fclose(save);
     }
     
@@ -180,14 +180,14 @@ void play(GtkButton *button, gpointer *pointer) {
     window = (GtkWidget*)pointer;
     FILE *save = fopen("score.bin", "rb");
     if(save != NULL){
-        fread(&meilleur_score, sizeof(unsigned __int16), 1, save);
+        fread(&meilleur_score, sizeof(unsigned int), 1, save);
         sprintf(score_text, "Pong, meilleur score : %d, score: %d", meilleur_score, score);
         fclose(save);
     }
     else{
         FILE *save = fopen("score.bin", "w+b");
         meilleur_score = 0;
-        fwrite(&meilleur_score, sizeof(unsigned __int16), 1, save);
+        fwrite(&meilleur_score, sizeof(unsigned int), 1, save);
         fclose(save);
     }
     start = time(NULL);

--- a/meson.build
+++ b/meson.build
@@ -2,8 +2,7 @@ project('Pong-GTK', 'c', version : '1.0.0')
 
 gtk_dep = dependency('gtk+-3.0', version: '>=3.22')
 
-game = library('game', 'Code/game.c', dependencies: gtk_dep)
-fonctions = library('functions', 'Code/functions.c', dependencies: gtk_dep)
+sources = ['Code/game.c', 'Code/main.c', 'Code/functions.c']
 
 # Compiler les ressources uniquement sous Windows
 if host_machine.system() == 'windows'
@@ -18,4 +17,4 @@ else
     compiled_targets = []
 endif
 
-executable('Pong_launcher', 'Code/main.c', compiled_targets, dependencies: gtk_dep, install: true, link_with: [game, fonctions])
+executable('Pong_launcher', sources, compiled_targets, dependencies: gtk_dep, install: true)


### PR DESCRIPTION
Juste comme ça, je te conseille de pas utliser `__int16` car ça marche que sous Windows. Surout qu'il y a des équivalents qui sont du pur C, et en l'occurrence c'est le type short mais dans ton code je l'ai remplacé par le type int, celui le plus courant, qui fait 32 bits.